### PR TITLE
test

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,3 +6,5 @@ and it should be rare that you have to call these directly.
 
 Please see the [`CONTRIBUTING.md` file](/CONTRIBUTING.md) for environment
 setup and usage information.
+
+a


### PR DESCRIPTION
feat: Allow content-type header if it only includes application/json for Splunk HEC source

## Summary
Updated the Splunk HEC source to accept requests that contain the header content-type with any value containing "application/json," not the exact value of "application/json."

## Change Type
- [ ] Bug fix
- [X] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [X] No

## How did you test this PR?
Test binary against a Splunk HEC and Vector.

### Against Vector before change:

curl -i -X POST "$MY_SERVER" -H "Authorization: Splunk $MY_TOKEN" -H "X-Splunk-Request-Channel: $(uuidgen)" -H 'Content-Type: application/json; profile=urn:splunk/event:1.0; charset=utf-8' --data '{"acks":[0]}' && echo
HTTP/1.1 415 Unsupported Media Type
content-type: text/plain; charset=utf-8
content-length: 43
date: Sat, 10 May 2025 16:02:02 GMT

The request's content-type is not supported

### Against Vector after change:

curl -i -X POST "$MY_SERVER" -H "Authorization: Splunk $MY_TOKEN" -H "X-Splunk-Request-Channel: $(uuidgen)" -H 'Content-Type: application/json; profile=urn:splunk/event:1.0; charset=utf-8' --data '{"acks":[0]}' && echo
HTTP/1.1 400 Bad Request
content-type: application/json
content-length: 36
date: Sat, 10 May 2025 16:00:48 GMT

{"text":"Ack is disabled","code":14}

### Against Splunk HEC:

curl -i -X POST "$MY_SERVER" -H "Authorization: Splunk $MY_TOKEN" -H "X-Splunk-Request-Channel: $(uuidgen)" -H 'Content-Type: application/json; profile=urn:splunk/event:1.0; charset=utf-8' --data '{"acks":[0]}' && echo
HTTP/1.1 400 Bad Request
Date: Sat, 10 May 2025 16:02:24 GMT
Content-Type: application/json; charset=UTF-8
X-Content-Type-Options: nosniff
Content-Length: 36
Vary: Authorization
Connection: Keep-Alive
X-Frame-Options: SAMEORIGIN
Server: Splunkd

{"text":"ACK is disabled","code":14}

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [X] No. A maintainer will apply the "no-changelog" label to this PR.

## References
Closes #23023